### PR TITLE
Multi-gpu error with gradio from gpu_infer cast type: 'str' object cannot be interpreted as an integer

### DIFF
--- a/vace/models/wan/wan_vace.py
+++ b/vace/models/wan/wan_vace.py
@@ -471,7 +471,7 @@ class WanVaceMP(WanVace):
     def dynamic_load(self):
         if hasattr(self, 'inference_pids') and self.inference_pids is not None:
             return
-        gpu_infer = os.environ.get('LOCAL_WORLD_SIZE') or torch.cuda.device_count()
+        gpu_infer = int(os.environ.get('LOCAL_WORLD_SIZE', torch.cuda.device_count()))
         pmi_rank = int(os.environ['RANK'])
         pmi_world_size = int(os.environ['WORLD_SIZE'])
         in_q_list = [torch.multiprocessing.Manager().Queue() for _ in range(gpu_infer)]


### PR DESCRIPTION
When running gradio with multi-gpu, it results in an error from gpu_infer being cast as a string because os.environ.get('LOCAL_WORLD_SIZE') returns a string.  This PR fixes it by casting to int